### PR TITLE
Win32changes

### DIFF
--- a/agg-src/include/platform/win32/agg_win32_bmp.h
+++ b/agg-src/include/platform/win32/agg_win32_bmp.h
@@ -20,6 +20,7 @@
 #define AGG_WIN32_BMP_INCLUDED
 
 
+#include <stdio.h>
 #include <windows.h>
 
 

--- a/agg-src/src/platform/win32/agg_platform_support.cpp
+++ b/agg-src/src/platform/win32/agg_platform_support.cpp
@@ -1235,7 +1235,7 @@ namespace agg
                      height + (height - (rct.bottom - rct.top)),
                      FALSE);
    
-        ::SetWindowLongPtr(m_specific->m_hwnd, GWLP_USERDATA, (LONG)this);
+        ::SetWindowLongPtr(m_specific->m_hwnd, GWLP_USERDATA, (LONG_PTR)this);
         m_specific->create_pmap(width, height, &m_rbuf_window);
         m_initial_width = width;
         m_initial_height = height;

--- a/agg-src/src/platform/win32/agg_platform_support.cpp
+++ b/agg-src/src/platform/win32/agg_platform_support.cpp
@@ -1447,7 +1447,7 @@ namespace agg
     //-----------------------------------------------------------------------
     inline int tokenizer::check_chr(const char *str, char chr)
     {
-        return int(strchr(str, chr));
+        return (strchr(str, chr)) ? 1 : 0;
     }
 
 


### PR DESCRIPTION
Three errors on modern MSYS2/MinGW64/QtCreator-4.5/gcc-9.2.0/cmake-3.15.6 - Windows7Home.
Probably gcc/g++ compiler is more strict now.
