### PR TITLE
Made examples and demo optional build options in cmake

### DIFF
--- a/agg-src/CMakeLists.txt
+++ b/agg-src/CMakeLists.txt
@@ -28,6 +28,16 @@ OPTION( agg_USE_SDL_PLATFORM "Use SDL as platform" OFF)
 OPTION( agg_USE_PACK "Package Agg" OFF)
 OPTION( agg_USE_AGG2D "Agg 2D graphical context" OFF)
 OPTION( agg_USE_DEBUG "For debug version" OFF)
+OPTION( agg_BUILD_EXAMPLES "Build the AGG examples" ON)
+OPTION( agg_BUILD_DEMO "Build the AGG demo" ON)
+OPTION( agg_BUILD_PLATFORM "Build the AGG platform helper" ON)
+OPTION( agg_BUILD_CONTROLS "Build the AGG controls" ON)
+
+IF( agg_BUILD_DEMO OR agg_BUILD_EXAMPLES )
+    MESSAGE(STATUS "Force enable the platform and controls helper due to Demo / Example being build.")
+    SET( agg_BUILD_PLATFORM ON CACHE BOOL "Build the AGG platform helper" FORCE)
+    SET( agg_BUILD_CONTROLS ON CACHE BOOL "Build the AGG controls" FORCE)
+ENDIF( agg_BUILD_DEMO OR agg_BUILD_EXAMPLES )
 
 IF( agg_USE_DEBUG )
     #SET( PFDEBUG "d" )
@@ -170,7 +180,7 @@ IF ( agg_USE_AGG2D_FREETYPE )
     SET( AGG_FLAGS ${AGG_FLAGS} -DAGG2D_USE_FREETYPE )    
 ENDIF ( agg_USE_AGG2D_FREETYPE )
 
-# sld as platform or os
+# sdl as platform or os
 IF( SDL_FOUND AND agg_USE_SDL_PLATFORM )
     LINK_LIBRARIES( controls sdlplatform antigrain )
     SET( AGG_LIBRARIES ${AGG_LIBRARIES} aggctrl${PFDEBUG} aggsdlplatform${PFDEBUG} agg${PFDEBUG} )
@@ -186,7 +196,9 @@ SET( AGG_LIBRARIES ${AGG_LIBRARIES} CACHE STRING "Agg package libraries" FORCE )
 
 ADD_SUBDIRECTORY( src )
 
-ADD_SUBDIRECTORY( examples )
+IF ( agg_BUILD_EXAMPLES )
+    ADD_SUBDIRECTORY( examples )
+ENDIF( agg_BUILD_EXAMPLES )
 
 CONFIGURE_FILE( ${antigrain_SOURCE_DIR}/bin/AggConfig.cmake.in
                 ${antigrain_BINARY_DIR}/bin/AggConfig.cmake
@@ -204,7 +216,9 @@ CONFIGURE_FILE( ${antigrain_SOURCE_DIR}/bin/UseAgg.cmake.in
                 ${antigrain_BINARY_DIR}/bin/UseAgg.cmake
                 @ONLY IMMEDIATE )
 
-ADD_SUBDIRECTORY( myapp )
+IF ( agg_BUILD_DEMO )
+    ADD_SUBDIRECTORY( myapp )
+ENDIF ( agg_BUILD_DEMO )
 
 INSTALL( FILES ${antigrain_BINARY_DIR}/bin/AggConfigOutBuild.cmake DESTINATION "bin" RENAME AggConfig.cmake )
 INSTALL( FILES ${antigrain_BINARY_DIR}/bin/AggConfig.cmake DESTINATION "bin" )

--- a/agg-src/src/CMakeLists.txt
+++ b/agg-src/src/CMakeLists.txt
@@ -158,32 +158,34 @@ ADD_LIBRARY( antigrain
 )
 
 #controls code for interactive modifying samples
-SET( controls_HEADERS   
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_slider_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_spline_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_scale_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_rbox_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_polygon_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_gamma_spline.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_gamma_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_cbox_ctrl.h
-    ${antigrain_SOURCE_DIR}/include/ctrl/agg_bezier_ctrl.h
-)
+IF( agg_BUILD_CONTROLS )
+    SET( controls_HEADERS
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_slider_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_spline_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_scale_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_rbox_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_polygon_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_gamma_spline.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_gamma_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_cbox_ctrl.h
+	${antigrain_SOURCE_DIR}/include/ctrl/agg_bezier_ctrl.h
+    )
 
-ADD_LIBRARY( controls    
-    ctrl/agg_spline_ctrl.cpp
-    ctrl/agg_slider_ctrl.cpp
-    ctrl/agg_scale_ctrl.cpp
-    ctrl/agg_rbox_ctrl.cpp
-    ctrl/agg_polygon_ctrl.cpp
-    ctrl/agg_gamma_spline.cpp
-    ctrl/agg_gamma_ctrl.cpp
-    ctrl/agg_cbox_ctrl.cpp
-    ctrl/agg_bezier_ctrl.cpp
+    ADD_LIBRARY( controls
+	ctrl/agg_spline_ctrl.cpp
+	ctrl/agg_slider_ctrl.cpp
+	ctrl/agg_scale_ctrl.cpp
+	ctrl/agg_rbox_ctrl.cpp
+	ctrl/agg_polygon_ctrl.cpp
+	ctrl/agg_gamma_spline.cpp
+	ctrl/agg_gamma_ctrl.cpp
+	ctrl/agg_cbox_ctrl.cpp
+	ctrl/agg_bezier_ctrl.cpp
 
-    ${controls_HEADERS}
-)
+	${controls_HEADERS}
+    )
+ENDIF( agg_BUILD_CONTROLS )
 
 #freetype library
 
@@ -201,47 +203,49 @@ IF ( agg_USE_FREETYPE )
 ENDIF ( agg_USE_FREETYPE )
 
 #platform stuff to ease sample use
-SET( platform_HEADERS   
-    ${antigrain_SOURCE_DIR}/include/platform/agg_platform_support.h
-)
-
-IF(WIN32)
-    INCLUDE_DIRECTORIES( ${antigrain_SOURCE_DIR}/font_win32_tt )
-
-    ADD_LIBRARY( platform
-        ../src/platform/win32/agg_win32_bmp.cpp
-        ../src/platform/win32/agg_platform_support.cpp
-        ../font_win32_tt/agg_font_win32_tt.cpp
-		
-		${platform_HEADERS}		
+IF( agg_BUILD_PLATFORM )
+    SET( platform_HEADERS
+	${antigrain_SOURCE_DIR}/include/platform/agg_platform_support.h
     )
-	INSTALL( FILES ../font_win32_tt/agg_font_win32_tt.h DESTINATION agg/font_win32_tt )	
-ENDIF(WIN32)
-IF(UNIX)
-    ADD_LIBRARY( platform
-        ../src/platform/X11/agg_platform_support.cpp
 
-		${platform_HEADERS}		
-    )
-ENDIF(UNIX)
-IF(APPLE)
-    ADD_LIBRARY( platform
-        ../src/platform/mac/agg_mac_pmap.cpp
-        ../src/platform/mac/agg_platform_support.cpp
+    IF(WIN32)
+        INCLUDE_DIRECTORIES( ${antigrain_SOURCE_DIR}/font_win32_tt )
 
-		${platform_HEADERS}		
-    )
-ENDIF(APPLE)
+	ADD_LIBRARY( platform
+	    ../src/platform/win32/agg_win32_bmp.cpp
+	    ../src/platform/win32/agg_platform_support.cpp
+	    ../font_win32_tt/agg_font_win32_tt.cpp
 
-IF( SDL_FOUND AND agg_USE_SDL_PLATFORM )
-    ADD_LIBRARY( sdlplatform
-        ../src/platform/sdl/agg_platform_support.cpp
-		
-		${platform_HEADERS}		
-    )
-    INSTALL( TARGETS sdlplatform DESTINATION lib )
-    SET_TARGET_PROPERTIES( sdlplatform  PROPERTIES OUTPUT_NAME aggsdlplatform${PFDEBUG} )
-ENDIF( SDL_FOUND AND agg_USE_SDL_PLATFORM )
+	            ${platform_HEADERS}
+	)
+            INSTALL( FILES ../font_win32_tt/agg_font_win32_tt.h DESTINATION agg/font_win32_tt )
+    ENDIF(WIN32)
+    IF(UNIX)
+        ADD_LIBRARY( platform
+	    ../src/platform/X11/agg_platform_support.cpp
+
+	            ${platform_HEADERS}
+	)
+    ENDIF(UNIX)
+    IF(APPLE)
+        ADD_LIBRARY( platform
+	    ../src/platform/mac/agg_mac_pmap.cpp
+	    ../src/platform/mac/agg_platform_support.cpp
+
+	            ${platform_HEADERS}
+	)
+    ENDIF(APPLE)
+
+    IF( SDL_FOUND AND agg_USE_SDL_PLATFORM )
+        ADD_LIBRARY( sdlplatform
+	    ../src/platform/sdl/agg_platform_support.cpp
+
+	            ${platform_HEADERS}
+	)
+        INSTALL( TARGETS sdlplatform DESTINATION lib )
+	SET_TARGET_PROPERTIES( sdlplatform  PROPERTIES OUTPUT_NAME aggsdlplatform${PFDEBUG} )
+    ENDIF( SDL_FOUND AND agg_USE_SDL_PLATFORM )
+ENDIF( agg_BUILD_PLATFORM )
 
 # boolean operations library GPC
 
@@ -270,10 +274,15 @@ IF ( agg_USE_AGG2D )
 ENDIF ( agg_USE_AGG2D )
 
 SET_TARGET_PROPERTIES( antigrain PROPERTIES OUTPUT_NAME agg${PFDEBUG} )
-SET_TARGET_PROPERTIES( controls  PROPERTIES OUTPUT_NAME aggctrl${PFDEBUG} )
-SET_TARGET_PROPERTIES( platform  PROPERTIES OUTPUT_NAME aggplatform${PFDEBUG} )
-
-INSTALL( FILES ${antigrain_HEADERS} DESTINATION agg/include )	
-INSTALL( FILES ${controls_HEADERS} DESTINATION agg/include/ctrl )	
-INSTALL( FILES ${platform_HEADERS} DESTINATION agg/include/platform )	
-INSTALL( TARGETS antigrain controls platform DESTINATION lib )
+INSTALL( FILES ${antigrain_HEADERS} DESTINATION agg/include )
+INSTALL( TARGETS antigrain DESTINATION lib )
+IF( agg_BUILD_PLATFORM )
+    SET_TARGET_PROPERTIES( platform  PROPERTIES OUTPUT_NAME aggplatform${PFDEBUG} )
+    INSTALL( FILES ${platform_HEADERS} DESTINATION agg/include/platform )
+    INSTALL( TARGETS platform DESTINATION lib )
+ENDIF( agg_BUILD_PLATFORM )
+IF( agg_BUILD_CONTROLS )
+    SET_TARGET_PROPERTIES( controls  PROPERTIES OUTPUT_NAME aggctrl${PFDEBUG} )
+    INSTALL( FILES ${controls_HEADERS} DESTINATION agg/include/ctrl )
+    INSTALL( TARGETS controls DESTINATION lib )
+ENDIF( agg_BUILD_CONTROLS )


### PR DESCRIPTION
I added following build options to make building as subproject a bit more comfortable.

- `agg_BUILD_EXAMPLES`
- `agg_BUILD_DEMO`
- `agg_BUILD_PLATFORM`
- `agg_BUILD_CONTROLS`

`agg_BUILD_PLATFORM` and `agg_BUILD_CONTROLS` are forced to true if either `agg_BUILD_EXAMPLES` or `agg_BUILD_DEMO` are set.
So by default nothing should have changed as examples and the demo are defaulting to ON.

Not sure this is of interest for you, but it can't harm to try to get it "upstream".