### PR TITLE
Fix compilation on msvc2019

### DIFF
--- a/agg-src/examples/win32_api/pure_api/pure_api.cpp
+++ b/agg-src/examples/win32_api/pure_api/pure_api.cpp
@@ -1,13 +1,13 @@
 // pure_api.cpp : Defines the entry point for the application.
 //
 
-#include "stdafx.h"
-#include "resource.h"
-
 #include "agg_scanline_p.h"
 #include "agg_renderer_scanline.h"
 #include "agg_pixfmt_rgba.h"
 #include "agg_rasterizer_scanline_aa.h"
+
+#include "stdafx.h"
+#include "resource.h"
 
 #define MAX_LOADSTRING 100
 

--- a/agg-src/font_win32_tt/agg_font_win32_tt.h
+++ b/agg-src/font_win32_tt/agg_font_win32_tt.h
@@ -16,7 +16,6 @@
 #ifndef AGG_FONT_WIN32_TT_INCLUDED
 #define AGG_FONT_WIN32_TT_INCLUDED
 
-#include <windows.h>
 #include "agg_scanline_storage_aa.h"
 #include "agg_scanline_storage_bin.h"
 #include "agg_scanline_u.h"
@@ -26,6 +25,8 @@
 #include "agg_conv_curve.h"
 #include "agg_trans_affine.h"
 #include "agg_font_cache_manager.h"
+
+#include <windows.h>
 
 namespace agg
 {


### PR DESCRIPTION
Fix compilation on msvc2019, windows.h header should be the last if you use std::algorithm