### PR TITLE
Fix multiple definitions linker error

### DIFF
--- a/agg-src/include/agg_trans_perspective.h
+++ b/agg-src/include/agg_trans_perspective.h
@@ -502,7 +502,7 @@ namespace agg
     }
 
     //------------------------------------------------------------------------
-    const trans_perspective& 
+    inline const trans_perspective&
     trans_perspective::multiply_inv(const trans_perspective& m)
     {
         trans_perspective t = m;
@@ -511,7 +511,7 @@ namespace agg
     }
 
     //------------------------------------------------------------------------
-    const trans_perspective&
+    inline const trans_perspective&
     trans_perspective::multiply_inv(const trans_affine& m)
     {
         trans_affine t = m;
@@ -520,7 +520,7 @@ namespace agg
     }
 
     //------------------------------------------------------------------------
-    const trans_perspective&
+    inline const trans_perspective&
     trans_perspective::premultiply_inv(const trans_perspective& m)
     {
         trans_perspective t = m;
@@ -529,7 +529,7 @@ namespace agg
     }
 
     //------------------------------------------------------------------------
-    const trans_perspective&
+    inline const trans_perspective&
     trans_perspective::premultiply_inv(const trans_affine& m)
     {
         trans_perspective t(m);
@@ -697,14 +697,14 @@ namespace agg
     }
 
     //------------------------------------------------------------------------
-    void trans_perspective::translation(double* dx, double* dy) const
+    inline void trans_perspective::translation(double* dx, double* dy) const
     {
         *dx = tx;
         *dy = ty;
     }
 
     //------------------------------------------------------------------------
-    void trans_perspective::scaling(double* x, double* y) const
+    inline void trans_perspective::scaling(double* x, double* y) const
     {
         double x1 = 0.0;
         double y1 = 0.0;
@@ -719,7 +719,7 @@ namespace agg
     }
 
     //------------------------------------------------------------------------
-    void trans_perspective::scaling_abs(double* x, double* y) const
+    inline void trans_perspective::scaling_abs(double* x, double* y) const
     {
         *x = std::sqrt(sx  * sx  + shx * shx);
         *y = std::sqrt(shy * shy + sy  * sy);


### PR DESCRIPTION
This error occurs when including agg_trans_perspective.h in multiple source files and then linking them together. This fix is inspired by the surrounding code, which avoids the problem by declaring functions as inline.